### PR TITLE
fix: pin reusable workflow to commit SHA

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,6 +31,6 @@ jobs:
       github.event.pull_request.draft == false
     name: Notify GChat
     needs: [podspec-lint]
-    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@main
+    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     secrets:
       gchat_webhook: ${{ secrets.GCHAT_PRS_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Pins `ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml` to a specific commit SHA instead of `@main`
- Mitigates supply chain risk — referencing by branch means any change to that branch automatically affects this repo's workflows

## Context
Flagged by [zizmor](https://github.com/zizmorcore/zizmor) static analysis as part of the org-wide GitHub Actions security rollout.

## Finding
- **Rule:** `unpinned-uses` (high severity, high confidence)
- **Risk:** If the upstream workflow is compromised or modified, this repo would automatically pull those changes

## What changed
`pull-request.yml` line 34: `@main` → `@1859338d7c2c2b873233505c751acbf09fb218d5 # main`

## Rollback
Revert this commit to restore the previous `@main` reference.