### PR TITLE
ci: deny-by-default permissions + job-level scoping, add zizmor CI

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -6,8 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+" # Stable: 2.3.0
       - "[0-9]+.[0-9]+.[0-9]+-*" # Prerelease: 2.3.0-alpha1
 
-permissions:
-  contents: read
+permissions: {} # deny-by-default; job below grants only what it needs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,10 +14,15 @@ concurrency:
 
 jobs:
   publish-cocoapods:
+    name: Publish to CocoaPods
     runs-on: macos-15
+    permissions:
+      contents: read # required by actions/checkout to pull the repo for linting + pushing the podspec
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate podspec
         run: pod lib lint DcuiSchema.podspec --allow-warnings --verbose

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,15 +1,12 @@
 name: Pull Request
 
-permissions:
-  contents: read
-  pull-requests: read
-  id-token: write
-
 on:
   push:
     branches:
       - master
   pull_request:
+
+permissions: {} # deny-by-default; each job grants only what it needs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -17,10 +14,15 @@ concurrency:
 
 jobs:
   podspec-lint:
+    name: Lint podspec
     runs-on: macos-15
+    permissions:
+      contents: read # required by actions/checkout to pull the repo
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Lint podspec
         run: pod lib lint DcuiSchema.podspec --allow-warnings --verbose
@@ -31,6 +33,10 @@ jobs:
       github.event.pull_request.draft == false
     name: Notify GChat
     needs: [podspec-lint]
+    permissions:
+      contents: read # reusable workflow below checks out its own repo
+      pull-requests: read # reusable workflow reads PR metadata (title, author, URL) for the notification payload
+      id-token: write # reusable workflow uses OIDC to authenticate to the GChat webhook
     uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     secrets:
       gchat_webhook: ${{ secrets.GCHAT_PRS_WEBHOOK }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,52 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {} # deny-by-default; job below grants only what it needs
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # actions: read — zizmor's online audits call the GitHub Actions API to
+    # resolve metadata for reusable workflows referenced by this repo
+    # (pull-request.yml calls ROKT/rokt-workflows/.../oss_pr_opened_notification.yml).
+    permissions:
+      contents: read # required by actions/checkout to pull the workflow tree
+      actions: read # see block comment above
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1 # zizmor only needs the tree at HEAD
+      # Advisory mode — zizmor is rolled out across Rokt repos as a reporter,
+      # not a blocking gate. Findings surface as PR annotations so owners can
+      # triage incrementally without blocking unrelated changes.
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        continue-on-error: true
+        with:
+          # advanced-security: false — no SARIF upload (GHAS not enabled on
+          # this repo). Switch to true and add `security-events: write` to
+          # job permissions if GHAS is ever enabled.
+          advanced-security: false
+          annotations: true # inline PR annotations (GitHub caps at 10/run)

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # see block comment above
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 1 # zizmor only needs the tree at HEAD


### PR DESCRIPTION
## Summary
Follows the same pattern as the other ROKT zizmor rollout PRs (vpc-finder #7, ska-reports #3, shopify_extensions #3, Jetson #23) — adds deny-by-default workflow permissions, scopes grants to the jobs that actually need them, fixes `artipacked` + `anonymous-definition`, and drops in an advisory-mode zizmor CI.

## Changes

**`cocoapods-publish.yml`**:
- Workflow-level `permissions:` is now deny-by-default (`{}`). `contents: read` moved into the `publish-cocoapods` job with an explanatory comment.
- Added `persist-credentials: false` on the checkout → closes `artipacked`.
- Named the job `Publish to CocoaPods` → closes `anonymous-definition`.

**`pull-request.yml`**:
- Workflow-level `permissions:` is now deny-by-default (`{}`). Notably, **dropped the workflow-level `id-token: write`** — only `pr-notify` needs it, so granting it to every job (including the lint job) was overly broad. Closes `excessive-permissions`.
- `podspec-lint` job: added `name:`, scoped `contents: read`, and `persist-credentials: false` on checkout.
- `pr-notify` job: scoped `contents: read` + `pull-requests: read` + `id-token: write` with inline comments. These grants exist because the reusable workflow (`ROKT/rokt-workflows/.../oss_pr_opened_notification.yml`) reads PR metadata and OIDC-auths the GChat webhook.
- Reordered `on:` before `permissions:` for readability.

**`zizmor.yml`** — new advisory-mode CI workflow matching every other ROKT repo in this rollout. `continue-on-error: true` so findings surface as PR annotations without blocking merges. Kept `actions: read` because this repo calls a reusable workflow in `ROKT/rokt-workflows`; zizmor's online audits need that scope to resolve metadata for same-org reusable workflows.

## Rationale
- **Advisory mode (not a required check)** — zizmor is rolling out across ROKT repos as a reporter, not a blocking gate. **Plan:** flip to blocking after the org-wide rollout finishes and initial findings are triaged.
- **`advanced-security: false`** — GHAS is not enabled on this repo (`security_and_analysis: null` via API). If it's ever turned on, flip this to `true` and add `security-events: write` to the zizmor job's permissions.

## Out of scope
- **1 remaining `secrets-outside-env` finding** on `COCOAPODS_TRUNK_TOKEN`. Fixing requires creating a GitHub Environment (e.g., `release`) in repo settings and attaching the secret to it, then adding `environment: release` to the `publish-cocoapods` job. Repo-settings change, handled separately.

## Test plan
- [ ] Zizmor CI workflow runs on this PR and reports only the 1 expected `secrets-outside-env` finding (advisory, non-blocking)
- [ ] After merge, the next PR triggers `podspec-lint` + `pr-notify` end-to-end. The `pr-notify` job successfully posts to the GChat webhook (confirms `id-token: write` + `pull-requests: read` on the job level are sufficient for the reusable workflow)
- [ ] Next tagged release triggers `publish-cocoapods` end-to-end — pod lint + pod trunk push succeed